### PR TITLE
Add support for multiple depots

### DIFF
--- a/engine/src/main/java/org/mides/optimization/model/Problem.java
+++ b/engine/src/main/java/org/mides/optimization/model/Problem.java
@@ -18,10 +18,6 @@ import java.util.Map;
 public class Problem {
 
     @NotNull
-    @JsonProperty("depot")
-    private Depot depot;
-
-    @NotNull
     @JsonProperty("vehicles")
     private List<Vehicle> vehicles = new ArrayList<>();
 
@@ -38,16 +34,30 @@ public class Problem {
     private Map<Integer, PickupDeliveryTask> tasksByIndex = new HashMap<>();
 
     public void initialize() {
-        depot.setIndex(0);
-        tasksByIndex.put(0, new PickupDeliveryTask(
-            0,
-            depot.getAddress(),
-            depot.getTimeWindow(),
-            depot.getCoordinates(),
-            depot.getId()
-        ));
 
-        int index = 1;
+        int index = 0;
+        for (Vehicle vehicle : vehicles) {
+            vehicle.getDepotStart().setIndex(index);
+            tasksByIndex.put(index, new PickupDeliveryTask(
+                index,
+                vehicle.getDepotStart().getAddress(),
+                vehicle.getDepotStart().getTimeWindow(),
+                vehicle.getDepotStart().getCoordinates(),
+                vehicle.getDepotStart().getId()
+            ));
+            index = index + 1;
+
+            vehicle.getDepotEnd().setIndex(index);
+            tasksByIndex.put(index, new PickupDeliveryTask(
+                index,
+                vehicle.getDepotEnd().getAddress(),
+                vehicle.getDepotEnd().getTimeWindow(),
+                vehicle.getDepotEnd().getCoordinates(),
+                vehicle.getDepotEnd().getId()
+            ));
+            index = index + 1;
+        }
+
         for (RideRequest ride : rideRequests) {
             ride.getPickup().setRide(ride);
             ride.getDelivery().setRide(ride);
@@ -71,7 +81,7 @@ public class Problem {
                 );
         }
 
-        numberOfNodes = rideRequests.size() * 2 + 1;
+        numberOfNodes = rideRequests.size() * 2 + vehicles.size() * 2;
     }
 
     public List<Coordinate> getAllCoordinates() {

--- a/engine/src/main/java/org/mides/optimization/model/Vehicle.java
+++ b/engine/src/main/java/org/mides/optimization/model/Vehicle.java
@@ -1,6 +1,7 @@
 package org.mides.optimization.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,11 @@ public class Vehicle {
     @JsonProperty("capacity")
     private double capacity;
 
-    @JsonProperty("time_window")
-    private TimeWindow timeWindow = new TimeWindow();
+    @NotNull
+    @JsonProperty("depot_start")
+    private Depot depotStart;
+
+    @NotNull
+    @JsonProperty("depot_end")
+    private Depot depotEnd;
 }


### PR DESCRIPTION
This pull request includes significant changes to the `Problem` and `Vehicle` classes and updates to the `ORToolsService` to accommodate the new structure. The most important changes include the removal of the `Depot` field from `Problem`, the addition of `depotStart` and `depotEnd` fields to `Vehicle`, and the corresponding updates in the `initialize` method and `solve` method.

### Changes to `Problem` class:
* Removed the `Depot` field from the `Problem` class.
* Updated the `initialize` method to handle `depotStart` and `depotEnd` for each vehicle.
* Adjusted the calculation of `numberOfNodes` to account for the new vehicle depot fields.

### Changes to `Vehicle` class:
* Added `depotStart` and `depotEnd` fields to the `Vehicle` class, both annotated with `@NotNull`.

### Changes to `ORToolsService` class:
* Updated the `solve` method to use `depotStart` and `depotEnd` indices for vehicles. [[1]](diffhunk://#diff-528ff1a66b9131a008961a262caf19d0893c3ccc8c9985766f5d9e5c84664b25R19-R37) [[2]](diffhunk://#diff-528ff1a66b9131a008961a262caf19d0893c3ccc8c9985766f5d9e5c84664b25L63-R73) [[3]](diffhunk://#diff-528ff1a66b9131a008961a262caf19d0893c3ccc8c9985766f5d9e5c84664b25L75-R92)
* Modified the `buildSolution` method to use the new time window fields from `depotStart` and `depotEnd`.