### PR TITLE
fix: increase max table size

### DIFF
--- a/osrm/Dockerfile
+++ b/osrm/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update && apk add --no-cache curl bash
 
 RUN chmod +x ./prepare_osrm_data.sh && ./prepare_osrm_data.sh
 
-CMD ["osrm-routed", "--algorithm", "ch", "/data/uruguay-latest.osrm"]
+CMD ["osrm-routed", "--algorithm", "ch", "--max-table-size", "5000", "/data/uruguay-latest.osrm"]


### PR DESCRIPTION
This pull request makes a minor improvement to the `osrm/Dockerfile` by updating the `CMD` instruction to include a new parameter for better configuration.

Dockerfile update:

* [`osrm/Dockerfile`](diffhunk://#diff-41a2388eb8d7d11321e6a77ac92ad690075060bbd0a9d304661ad10b0fa9b4a0L9-R9): Added the `--max-table-size` parameter with a value of `5000` to the `osrm-routed` command for enhanced table size configuration.